### PR TITLE
fixed build error;  multiple instances of RCTBridge

### DIFF
--- a/RNDeviceAngles/DeviceAngles.m
+++ b/RNDeviceAngles/DeviceAngles.m
@@ -5,7 +5,7 @@
 //  Created by Cristian Szwarc on 20/08/16.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "DeviceAngles.h"
 
@@ -17,10 +17,10 @@ RCT_EXPORT_MODULE();
 
 - (id) init {
     self = [super init];
-    
+
     if (self) {
         self->_motionManager = [[CMMotionManager alloc] init];
-        
+
         if([self->_motionManager isGyroAvailable])
         {
             NSLog(@"gyroscope is available");
@@ -42,24 +42,24 @@ RCT_EXPORT_METHOD(getDeviceMotionUpdateInterval:(RCTResponseSenderBlock) callbac
 
 RCT_EXPORT_METHOD(startMotionUpdates) {
     [self->_motionManager startDeviceMotionUpdates];
-    
+
     [self->_motionManager startDeviceMotionUpdatesToQueue:[NSOperationQueue mainQueue]
                                               withHandler:^(CMDeviceMotion *devMotion, NSError *error)
     {
         CMAttitude *attitude;
         attitude = devMotion.attitude;
-        
+
         float pitch =  (180/M_PI) * attitude.pitch;
         float roll = (180/M_PI) * attitude.roll;
         float yaw = (180/M_PI) * attitude.yaw;
-        
+
         [self.bridge.eventDispatcher sendDeviceEventWithName:@"AnglesData" body:@{
                                                                                   @"pitch" : [NSNumber numberWithDouble:pitch],
                                                                                   @"roll" : [NSNumber numberWithDouble:roll],
                                                                                   @"yaw" : [NSNumber numberWithDouble:yaw]
                                                                                   }];
     }];
-    
+
 }
 
 RCT_EXPORT_METHOD(stopMotionUpdates) {


### PR DESCRIPTION
the compiler in xcode was failing because of an update to react-native; 

I fixed it by changing the import statement.

Please merge soon, so that the change will be available on npm.  This is a big pain.  I've had to update the file manually every time I build.

Thanks for your work on this project.  It's a big help.